### PR TITLE
Fix link on homepage

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -2,8 +2,8 @@ require 'sinatra'
 require 'json'
 
 get '/' do
-  'Battlesnake documentation can be found at' \
-    '<a href=\"https://docs.battlesnake.io\">https://docs.battlesnake.io</a>.'
+  'Battlesnake documentation can be found at ' \
+    '<a href="https://docs.battlesnake.io">https://docs.battlesnake.io</a>.'
 end
 
 post '/start' do


### PR DESCRIPTION
Don't escape double-quotes in a single-quoted string! This was making the link on the index page unclickable, as the quotes were being interpreted as part of the URL.